### PR TITLE
Update default arguments to GenTSAnomVars()

### DIFF
--- a/R/GenTSAnomVars.R
+++ b/R/GenTSAnomVars.R
@@ -37,13 +37,13 @@
 #' @export
 GenTSAnomVars <- function(data,
                           ValueCol    = "Value",
-                          GroupVar1   = "SKU",
+                          GroupVar1   = NULL,
                           GroupVar2   = NULL,
                           DateVar     = "DATE",
                           HighThreshold = 1.96,
                           LowThreshold  = -1.96,
-                          KeepAllCols = FALSE,
-                          IsDataScaled  = TRUE) {
+                          KeepAllCols = TRUE,
+                          IsDataScaled  = FALSE) {
   # Check data.table
   if (!data.table::is.data.table(data))
     data <- data.table::as.data.table(data)


### PR DESCRIPTION
- Set default GroupVar1 to NULL (currently set to "SKU")
- Set default KeepAllCols to TRUE. Reason is so user can see how AnomHighRate and AnomLowRate are being calculated. Also, the 1s and 0s in AnomHigh and AnomLow can be immediately available for use for anomaly detection
- Set IsDataScaled to FALSE. This is because most users probably won't z-scale their data beforehand. And the GenTSAnomVars() function handles the scaling nicely already (if the data is not z-scaled).