### PR TITLE
Updated ResidualOutliers function

### DIFF
--- a/R/ResidualOutliers.R
+++ b/R/ResidualOutliers.R
@@ -84,7 +84,7 @@ ResidualOutliers <- function(data,
   
   # Convert to time series object
   tsData <- stats::ts(temp,
-                      start = temp[, min(get(DateColName))][[1]],
+                      start = temp[, min(as.POSIXct(get(DateColName)))][[1]],
                       frequency = freq)
   
   # Build the auto arimia


### PR DESCRIPTION
When temp is being converted into a <code>ts()</code> object, getting the following error:

```
Error in start + (ndata - 1)/frequency : 
  non-numeric argument to binary operator
```

Error gets fixed when you wrap a <code>as.POSIXct()</code> around <code>get(DateColName)</code> which converts DateColName into a datetime.